### PR TITLE
修复“在屏幕边缘显示图标”开启时的问题

### DIFF
--- a/Extension/CameraExtension.cs
+++ b/Extension/CameraExtension.cs
@@ -1,10 +1,10 @@
-using System;
+﻿using System;
 using Microsoft.Xna.Framework;
 using Monocle;
 
 namespace Celeste.Mod.StrawberryTool.Extension {
     public static class CameraExtension {
-        public static Vector2 GetIntersectionPoint(this Camera camera, Vector2 start, Vector2 end, float margin = 0f) {
+        public static Vector2? GetIntersectionPoint(this Camera camera, Vector2 start, Vector2 end, float margin = 0f) {
             float marginX = Math.Min(camera.Viewport.Width / 2f, margin);
             float marginY = Math.Min(camera.Viewport.Height / 2f, margin);
             Vector2 marginVector = new Vector2(marginX, marginY);
@@ -17,14 +17,14 @@ namespace Celeste.Mod.StrawberryTool.Extension {
             };
 
             for (int i = 0; i < borderPoints.Length; i++) {
-                Vector2 result = FindIntersection(borderPoints[i], borderPoints[(i + 1) % borderPoints.Length],
+                Vector2? result = FindIntersection(borderPoints[i], borderPoints[(i + 1) % borderPoints.Length],
                     start, end);
-                if (!result.Equals(default)) {
+                if (result != null) {
                     return result;
                 }
             }
 
-            return default;
+            return null;
         }
 
         public static Vector2 Center(this Camera camera) {
@@ -47,10 +47,8 @@ namespace Celeste.Mod.StrawberryTool.Extension {
             return new Vector2(camera.Right, camera.Bottom);
         }
 
-        private static Vector2 FindIntersection(
+        private static Vector2? FindIntersection(
             Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4) {
-            Vector2 intersection = default;
-
             // Get the segments' parameters.
             float dx12 = p2.X - p1.X;
             float dy12 = p2.Y - p1.Y;
@@ -65,13 +63,13 @@ namespace Celeste.Mod.StrawberryTool.Extension {
                 / denominator;
             if (float.IsInfinity(t1)) {
                 // The lines are parallel (or close enough to it).
-                return default;
+                return null;
             }
 
             float t2 = ((p3.X - p1.X) * dy12 + (p1.Y - p3.Y) * dx12) / -denominator;
 
             // Find the point of intersection.
-            intersection = new Vector2(p1.X + dx12 * t1, p1.Y + dy12 * t1);
+            Vector2 intersection = new Vector2(p1.X + dx12 * t1, p1.Y + dy12 * t1);
 
             // The segments intersect if t1 and t2 are between 0 and 1.
             bool segments_intersect = t1 >= 0 && t1 <= 1 && t2 >= 0 && t2 <= 1;
@@ -80,7 +78,7 @@ namespace Celeste.Mod.StrawberryTool.Extension {
                 return intersection;
             }
 
-            return default;
+            return null;
         }
     }
 }

--- a/Extension/CameraExtension.cs
+++ b/Extension/CameraExtension.cs
@@ -1,27 +1,27 @@
-﻿using Microsoft.Xna.Framework;
+using System;
+using Microsoft.Xna.Framework;
 using Monocle;
 
 namespace Celeste.Mod.StrawberryTool.Extension {
     public static class CameraExtension {
         public static Vector2 GetIntersectionPoint(this Camera camera, Vector2 start, Vector2 end, float margin = 0f) {
-            Vector2 result = FindIntersection(camera.TopLeft(), camera.BottomLeft(), start, end);
-            if (!result.Equals(default)) {
-                return result + Vector2.UnitX * margin;
-            }
-            
-            result = FindIntersection(camera.TopRight(), camera.BottomRight(), start, end);
-            if (!result.Equals(default)) {
-                return result - Vector2.UnitX * margin;
-            }
-            
-            result = FindIntersection(camera.TopLeft(), camera.TopRight(), start, end);
-            if (!result.Equals(default)) {
-                return result + Vector2.UnitY * margin;
-            }
-            
-            result = FindIntersection(camera.BottomLeft(), camera.BottomRight(), start, end);
-            if (!result.Equals(default)) {
-                return result - Vector2.UnitY * margin;
+            float marginX = Math.Min(camera.Viewport.Width / 2f, margin);
+            float marginY = Math.Min(camera.Viewport.Height / 2f, margin);
+            Vector2 marginVector = new Vector2(marginX, marginY);
+
+            Vector2[] borderPoints = {
+                camera.TopLeft() + marginVector * new Vector2(1f, 1f),
+                camera.TopRight() + marginVector * new Vector2(-1f, 1f),
+                camera.BottomRight() + marginVector * new Vector2(-1f, -1f),
+                camera.BottomLeft() + marginVector * new Vector2(1f, -1f)
+            };
+
+            for (int i = 0; i < borderPoints.Length; i++) {
+                Vector2 result = FindIntersection(borderPoints[i], borderPoints[(i + 1) % borderPoints.Length],
+                    start, end);
+                if (!result.Equals(default)) {
+                    return result;
+                }
             }
 
             return default;

--- a/Feature/Detector/CollectablePointer.cs
+++ b/Feature/Detector/CollectablePointer.cs
@@ -164,7 +164,7 @@ namespace Celeste.Mod.StrawberryTool.Feature.Detector {
 
             sprite.Color = Color.White * alpha * (Settings.ShowIcon ? 1 : 0) * (collectableInCameraView ? 0 : 1);
 
-            if (alpha > 0 && Settings.ShowIcon && Settings.ShowIconAtScreenEdge) {
+            if (alpha > 0 && Settings.ShowIcon && Settings.ShowIconAtScreenEdge && !collectableInCameraView) {
                 light.Visible = bloom.Visible = true;
             }
 

--- a/Feature/Detector/CollectablePointer.cs
+++ b/Feature/Detector/CollectablePointer.cs
@@ -27,6 +27,7 @@ namespace Celeste.Mod.StrawberryTool.Feature.Detector {
         private Level level;
         private VertexLight light;
         private BloomPoint bloom;
+        private bool collectableInCameraView;
 
         public CollectablePointer(EntityData followerPosition, CollectableConfig collectableConfig) {
             EntityData = followerPosition;
@@ -80,7 +81,9 @@ namespace Celeste.Mod.StrawberryTool.Feature.Detector {
             }
 
             if (Settings.ShowIconAtScreenEdge) {
-                Position = GetCameraEdgePosition(level.Camera.Center());
+                Vector2? position = GetCameraEdgePosition(level.Camera.Center());
+                collectableInCameraView = (position == null);
+                Position = position ?? followerPosition;
             } else {
                 Position = GetAroundPlayerPosition(player, IconLength);
             }
@@ -159,7 +162,7 @@ namespace Celeste.Mod.StrawberryTool.Feature.Detector {
 
             lastAlpha = alpha;
 
-            sprite.Color = Color.White * alpha * (Settings.ShowIcon ? 1 : 0);
+            sprite.Color = Color.White * alpha * (Settings.ShowIcon ? 1 : 0) * (collectableInCameraView ? 0 : 1);
 
             if (alpha > 0 && Settings.ShowIcon && Settings.ShowIconAtScreenEdge) {
                 light.Visible = bloom.Visible = true;
@@ -195,7 +198,7 @@ namespace Celeste.Mod.StrawberryTool.Feature.Detector {
                 .Round();
         }
 
-        private Vector2 GetCameraEdgePosition(Vector2 position) {
+        private Vector2? GetCameraEdgePosition(Vector2 position) {
             return level.Camera.GetIntersectionPoint(position, followerPosition, 5f);
         }
 


### PR DESCRIPTION
### 修改探测器图标在屏幕角落的显示样式

修改前：
![Snipaste_2020-11-22_17-07-36](https://user-images.githubusercontent.com/7558201/99899557-50d1ed00-2ce5-11eb-895e-53c515de69b5.png)
修改后：
![Snipaste_2020-11-22_17-07-53](https://user-images.githubusercontent.com/7558201/99899560-53344700-2ce5-11eb-90a8-b693ec704229.png)

### 在视野范围内收集物对应的探测器图标会跑到 (0, 0)

![image](https://user-images.githubusercontent.com/7558201/99899694-3d735180-2ce6-11eb-8f98-1a5c10ab2944.png)

原先在两条线段不相交的情况下，`Camera.FindIntersection` 函数返回 `default`，由于 `Vector2` 是 `struct`，所以实际上返回的是 `Vector2(0f, 0f)`，现在改为返回 `null`，并且使用了一个新的变量 `collectableInCameraView` 判断收集品是否在视野范围内，是的话直接将图标的 alpha 值设为 0 将其隐藏