### PR TITLE
修复一局中收集磁带后，死亡复活依然会显示探测器

### DIFF
--- a/Feature/Detector/CollectableConfig.cs
+++ b/Feature/Detector/CollectableConfig.cs
@@ -97,7 +97,7 @@ namespace Celeste.Mod.StrawberryTool.Feature.Detector {
             },
 
             new CollectableConfig {
-                ShouldBeAdded = (level, data) => data.Name == "cassette",
+                ShouldBeAdded = (level, data) => data.Name == "cassette" && !level.Session.Cassette,
                 Scale = 0.4f,
                 HasCollected = data => SaveData.Instance.Areas[(Engine.Scene as Level).Session.Area.ID].Cassette,
                 ShouldDetect = () => Settings.DetectCassettes


### PR DESCRIPTION
`Level.LoadLevel()` 中加载磁带时会判断这一局是否有收集磁带，如果有的话实体就不会添加到关卡场景中
```csharp
if (name == "cassette") {
    bool flag62 = !this.Session.Cassette;
    if (flag62) {
        base.Add(new Cassette(entityData, vector));
    }
}
```