### PR TITLE
不探测当前房间且在有收集品的房间时，探测器指针数量保持不变

### DIFF
--- a/Feature/Detector/CollectablePointer.cs
+++ b/Feature/Detector/CollectablePointer.cs
@@ -160,10 +160,9 @@ namespace Celeste.Mod.StrawberryTool.Feature.Detector {
             var list = level.Entities
                 .FindAll<CollectablePointer>()
                 .FindAll(pointer => pointer.collectableConfig.ShouldDetect());
-            int currentRoomCounts = list.Count(pointer => level.Session.LevelData == pointer.EntityData.Level);
             list.Sort((pointer, collectablePointer) => Math.Sign(collectablePointer.Alpha - pointer.Alpha));
             int index = list.IndexOf(this);
-            if (index == -1 || index >= Settings.MaxPointers - (Settings.DetectCurrentRoom ? 0 : currentRoomCounts)) {
+            if (index == -1 || index >= Settings.MaxPointers) {
                 alpha = 0;
             }
 


### PR DESCRIPTION
没开探测当前房间，最大探测数量是 5，当前房间有 2 个收集品的话，显示的指针个数应该仍为 5，而不是 3